### PR TITLE
fixed undefined "simulation/mars/common/lib_manager" package

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -34,6 +34,7 @@ in_flavor 'master' do
     mars_package("simulation/mars/plugins/Text3D")
     mars_package("simulation/mars/common/graphics/osg_text")
     mars_package("simulation/mars/common/graphics/osg_text_factory")
+    mars_package("simulation/mars/common/graphics/osg_lines")
 end
 
 in_flavor 'next','stable' do
@@ -41,7 +42,7 @@ in_flavor 'next','stable' do
 end
 
 in_flavor 'master','next','stable' do
-    mars_package("simulation/mars/common/graphics/osg_lines")
+
     mars_package("simulation/mars/scripts/cmake")
     mars_package("simulation/mars/common/cfg_manager")
     mars_package("simulation/mars/common/gui/main_gui")

--- a/libs.autobuild
+++ b/libs.autobuild
@@ -36,7 +36,7 @@ in_flavor 'master' do
     mars_package("simulation/mars/common/graphics/osg_text_factory")
 end
 
-only_in_flavor 'next','stable' do
+in_flavor 'next','stable' do
     mars_package("simulation/mars/common/lib_manager")
 end
 


### PR DESCRIPTION
I don't really know the difference, but using "only_in_flavor" leaves the package undefined.

Can't tell the difference of "only_in" and  "in" anyways ;-)