### PR TITLE
fixing automake dependency

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -83,7 +83,6 @@ end
 in_flavor 'master','next','stable' do
     cmake_package 'external/minizip'
     autotools_package 'simulation/ode' do |pkg|
-        pkg.depends_on 'libtool'
         pkg.provides "pkgconfig/ode"
         pkg.configureflags <<
             "--enable-double-precision" <<

--- a/manifests/simulation/ode.xml
+++ b/manifests/simulation/ode.xml
@@ -1,0 +1,8 @@
+<package>
+    <description brief="ode">
+       open dynamics engine
+    </description>
+
+    <depend package="automake" />
+    <depend package="libtool" />
+</package>

--- a/mars.osdeps
+++ b/mars.osdeps
@@ -4,6 +4,9 @@ libtool:
     opensuse: libtool
     darwin: glibtool
 
+automake:
+    debian, ubuntu: [automake]
+
 zlib: 
     debian,ubuntu: zlib1g-dev
     opensuse: zlib-devel


### PR DESCRIPTION
Fix for automake dependency, also move libtool dependency to manifext.xml, to avoid different places for the dependencies. 