### PR TITLE
Import rock.cpp for tools dependencies.

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -3,6 +3,7 @@ name: rock.simulation
 imports:
     - github: rock-core/rock-package_set
     - github: rock-core/package_set
+    - github: rock-cpp/package_set
     - github: dfki-ric/bagel_package_set
 
 version_control:


### PR DESCRIPTION
@malter Do not merge before https://github.com/rock-cpp/package_set/pull/14 , otherwise there will be a circular dependency.